### PR TITLE
Force disable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,8 @@ Then similarly to the local setup, set the correct agent URI inside codespaces:
 ```shell
 DD_AGENT_URI=http://datadog_agent:8126 bin/rails s -p 50130
 ```
+
+### Disabling
+
+By default statsd and tracing are enabled by simply including this gem into an environment that has the `ECS_ENABLE_CONTAINER_METADATA` or `DD_AGENT_URI` environment variables enabled above, and the `RAILS_ENV` is set to either `production` or `staging`. If there are cases where you do want to disable it, you can set the ENV var `DISABLE_DEGICA_DATADOG=true` and you will force disable this gem.
+

--- a/lib/degica_datadog/config.rb
+++ b/lib/degica_datadog/config.rb
@@ -16,6 +16,8 @@ module DegicaDatadog
       end
 
       def enabled?
+        return false if disable_env_var_flag
+
         %w[production staging].include?(environment) || ENV.fetch("DD_AGENT_URI", nil)
       end
 
@@ -68,6 +70,13 @@ module DegicaDatadog
       def inspect
         "DegicaDatadog::Config<enabled?=#{!!enabled?} service=#{service} version=#{version} environment=#{environment} repository_url=#{repository_url} datadog_agent_host=#{datadog_agent_host} statsd_port=#{statsd_port} tracing_port=#{tracing_port}>" # rubocop:disable Layout/LineLength
       end
-    end
+
+      private
+
+      def disable_env_var_flag
+        ENV['DISABLE_DEGICA_DATADOG'] == 'true' ||
+        ENV['DISABLE_DEGICA_DATADOG'] == '1'
+      end
+    end # class << self
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe DegicaDatadog::Config do
       }
       expect(!!described_class.enabled?).to be(true)
     end
+
+    it "is false when the env var flag is set" do
+      allow(described_class).to receive(:disable_env_var_flag).and_return(true)
+      expect(described_class.enabled?).to eq(false)
+    end
   end
 
   describe ".datadog_agent_uri" do


### PR DESCRIPTION
This adds a DISABLE_DEGICA_DATADOG env var that can be used to simply force disable the statsd and tracing where we don't need them, to reduce costs where necessary.
