### PR TITLE
feat!: upgrade to datadog v2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,5 +10,8 @@ Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
 
+Metrics:
+  Enabled: false
+
 Layout/LineLength:
   Max: 120

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,9 @@ GEM
       libdatadog (~> 10.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
+    datadog-ci (1.3.0)
+      datadog (~> 2.2)
+      msgpack
     debase-ruby_core_source (3.3.1)
     diff-lcs (1.5.0)
     docile (1.4.1)
@@ -76,6 +79,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  datadog-ci
   degica_datadog!
   rspec (~> 3.0)
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,8 +59,6 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
-    rubocop-rspec (3.0.0)
-      rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -81,7 +79,6 @@ DEPENDENCIES
   degica_datadog!
   rspec (~> 3.0)
   rubocop
-  rubocop-rspec
   simplecov
   simplecov-cobertura
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,8 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
+    rubocop-rspec (3.0.0)
+      rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -79,6 +81,7 @@ DEPENDENCIES
   degica_datadog!
   rspec (~> 3.0)
   rubocop
+  rubocop-rspec
   simplecov
   simplecov-cobertura
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,29 +2,26 @@ PATH
   remote: .
   specs:
     degica_datadog (0.1.0)
-      ddtrace (~> 1.0)
+      datadog (~> 2.0)
       dogstatsd-ruby (~> 5)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    datadog-ci (0.5.1)
-      msgpack
-    ddtrace (1.18.0)
-      datadog-ci (~> 0.5.0)
-      debase-ruby_core_source (= 3.2.3)
-      libdatadog (~> 5.0.0.1.0)
+    datadog (2.2.0)
+      debase-ruby_core_source (= 3.3.1)
+      libdatadog (~> 10.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
-    debase-ruby_core_source (3.2.3)
+    debase-ruby_core_source (3.3.1)
     diff-lcs (1.5.0)
     docile (1.4.1)
     dogstatsd-ruby (5.6.1)
-    ffi (1.16.3)
+    ffi (1.17.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (5.0.0.1.0)
+    libdatadog (10.0.0.1.0)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     msgpack (1.7.2)
@@ -86,4 +83,4 @@ DEPENDENCIES
   simplecov-cobertura
 
 BUNDLED WITH
-   2.2.33
+   2.5.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     degica_datadog (0.1.0)
       datadog (~> 2.0)
+      datadog-ci (~> 1.0)
       dogstatsd-ruby (~> 5)
 
 GEM
@@ -79,7 +80,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
-  datadog-ci
   degica_datadog!
   rspec (~> 3.0)
   rubocop

--- a/degica_datadog.gemspec
+++ b/degica_datadog.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ddtrace", "~> 1.0"
+  spec.add_dependency "datadog", "~> 2.0"
   spec.add_dependency "dogstatsd-ruby", "~> 5"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/degica_datadog.gemspec
+++ b/degica_datadog.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "datadog", "~> 2.0"
+  spec.add_dependency "datadog-ci", "~> 1.0"
   spec.add_dependency "dogstatsd-ruby", "~> 5"
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "datadog-ci"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"

--- a/degica_datadog.gemspec
+++ b/degica_datadog.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "datadog", "~> 2.0"
   spec.add_dependency "dogstatsd-ruby", "~> 5"
   spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "datadog-ci"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"

--- a/lib/degica_datadog/statsd.rb
+++ b/lib/degica_datadog/statsd.rb
@@ -13,7 +13,7 @@ module DegicaDatadog
       # - <name>.95percentile
       #
       # The reported time is in milliseconds.
-      def with_timing(name, tags: {}) # rubocop:disable Metrics/MethodLength
+      def with_timing(name, tags: {})
         if Config.enabled?
           start = Time.now.to_f
           begin

--- a/lib/degica_datadog/tracing.rb
+++ b/lib/degica_datadog/tracing.rb
@@ -4,15 +4,15 @@ require "datadog"
 
 module DegicaDatadog
   # Tracing related functionality.
-  module Tracing # rubocop:disable Metrics/ModuleLength
-    class << self # rubocop:disable Metrics/ClassLength
+  module Tracing
+    class << self
       # Initialize Datadog tracing. Call this in from config/application.rb.
-      def init(rake_tasks: []) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+      def init(rake_tasks: [])
         return unless Config.enabled?
 
         require "datadog/auto_instrument"
 
-        Datadog.configure do |c| # rubocop:disable Metrics/BlockLength
+        Datadog.configure do |c|
           c.service = Config.service
           c.env = Config.environment
           c.version = Config.version
@@ -126,7 +126,7 @@ module DegicaDatadog
       # To pass in nested data to DD we need to pass keys separated with a "."
       # eg, "outer.inner". This method takes a nested hash and flattens it by
       # creating DD compatible key names.
-      def flatten_hash_for_span(hsh, key = nil) # rubocop:disable Metrics/MethodLength
+      def flatten_hash_for_span(hsh, key = nil)
         flattened_hash = {}
         hsh.each do |k, v|
           flattened_key = [key, k].compact.join(".")

--- a/lib/degica_datadog/tracing.rb
+++ b/lib/degica_datadog/tracing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "ddtrace"
+require "datadog"
 
 module DegicaDatadog
   # Tracing related functionality.
@@ -10,7 +10,7 @@ module DegicaDatadog
       def init(rake_tasks: []) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
         return unless Config.enabled?
 
-        require "ddtrace/auto_instrument"
+        require "datadog/auto_instrument"
 
         Datadog.configure do |c| # rubocop:disable Metrics/BlockLength
           c.service = Config.service

--- a/lib/degica_datadog/tracing.rb
+++ b/lib/degica_datadog/tracing.rb
@@ -34,7 +34,7 @@ module DegicaDatadog
           # Enabling additional settings for these instrumentations.
           c.tracing.instrument :rails, request_queueing: true
           c.tracing.instrument :rack, request_queueing: true
-          c.tracing.instrument :sidekiq, distributed_tracing: true, tag_args: true
+          c.tracing.instrument :sidekiq, distributed_tracing: true, quantize: { args: { show: :all } }
           c.tracing.instrument :active_support, cache_service: Config.service
           c.tracing.instrument :active_record, service_name: Config.service
           c.tracing.instrument(:mysql2, service_name: "#{Config.service}-#{Config.environment}",

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
 RSpec.describe DegicaDatadog::Config do
   describe ".init" do
     context "full initialisation" do

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
 RSpec.describe DegicaDatadog::Statsd do
   let(:stub_client) { double }
 
@@ -130,4 +129,3 @@ RSpec.describe DegicaDatadog::Statsd do
     end
   end
 end
-# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Changes:
1. Upgrade to datadog v2
2. Add some tests to cover tracing.rb
3. Disable `Metric` rubocop