### PR TITLE
Add prefix to the version name

### DIFF
--- a/lib/degica_datadog/config.rb
+++ b/lib/degica_datadog/config.rb
@@ -30,7 +30,7 @@ module DegicaDatadog
       end
 
       def version
-        @version || ENV.fetch("_GIT_REVISION", "unknown")
+        @version || (ENV.fetch("PLATFORM", "") + ENV.fetch("_GIT_REVISION", "unknown"))
       end
 
       def environment

--- a/lib/degica_datadog/config.rb
+++ b/lib/degica_datadog/config.rb
@@ -30,7 +30,11 @@ module DegicaDatadog
       end
 
       def version
-        @version || (ENV.fetch("PLATFORM", "") + ENV.fetch("_GIT_REVISION", "unknown"))
+        return @version if @version
+
+        platform = ENV.fetch("PLATFORM", "")
+        git_revision = ENV.fetch("_GIT_REVISION", "unknown")
+        platform.empty? ? git_revision : "#{platform}-#{git_revision}"
       end
 
       def environment

--- a/lib/degica_datadog/config.rb
+++ b/lib/degica_datadog/config.rb
@@ -34,7 +34,7 @@ module DegicaDatadog
 
         platform = ENV.fetch("PLATFORM", "")
         git_revision = ENV.fetch("_GIT_REVISION", "unknown")
-        platform.empty? ? git_revision : "#{platform}-#{git_revision}"
+        platform.empty? ? git_revision : "#{git_revision}-#{platform}"
       end
 
       def environment

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe DegicaDatadog::Config do
       end
 
       it "sets version correctly" do
-        expect(described_class.version).to eq("#{platform}#{version}")
+        expect(described_class.version).to eq("#{platform}-#{version}")
       end
     end
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe DegicaDatadog::Config do
       end
 
       it "sets version correctly" do
-        expect(described_class.version).to eq("#{platform}-#{version}")
+        expect(described_class.version).to eq("#{version}-#{platform}")
       end
     end
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe DegicaDatadog::Config do
         described_class.init
 
         allow(ENV).to receive(:fetch).with("SERVICE_NAME", "unknown").and_return(service_name)
+        allow(ENV).to receive(:fetch).with("PLATFORM", "").and_return("")
         allow(ENV).to receive(:fetch).with("_GIT_REVISION", "unknown").and_return(version)
         allow(ENV).to receive(:fetch).with("RAILS_ENV", "unknown").and_return(environment)
       end
@@ -61,6 +62,22 @@ RSpec.describe DegicaDatadog::Config do
 
       it "sets repository_url correctly" do
         expect(described_class.repository_url).to eq("github.com/degica/#{service_name}")
+      end
+    end
+
+    context "fetches from env on codepipeline" do
+      let(:version) { "mocked_version" }
+      let(:platform) { "cpp" } # codepipeline prefix
+
+      before do
+        described_class.init
+
+        allow(ENV).to receive(:fetch).with("PLATFORM", "").and_return(platform)
+        allow(ENV).to receive(:fetch).with("_GIT_REVISION", "unknown").and_return(version)
+      end
+
+      it "sets version correctly" do
+        expect(described_class.version).to eq("#{platform}#{version}")
       end
     end
   end


### PR DESCRIPTION
## Context
Since SRE will rollout Codepipeline (the new deployment system) next week with 1% weighted routing, we want to see two different versions in the [APM view](https://app.datadoghq.com/apm/services/hats/operations/rack.request/resources) to distinguish traffic between Barcelona and Codepipeline.

## Changes
We cannot update `_GIT_REVISION` env var during the deployment pipeline on Codepipeline, so we plan to add a new environment variable to add a prefix to the version. (We won't add the env var for Barcelona)

## Note
If there is a better way to achieve the goal, please let me know!