### PR TITLE
Normalize redemption service name

### DIFF
--- a/lib/degica_datadog/tracing.rb
+++ b/lib/degica_datadog/tracing.rb
@@ -69,11 +69,12 @@ module DegicaDatadog
           Datadog::Tracing::Pipeline::SpanFilter.new do |span|
             span.service == "collector.newrelic.com"
           end,
-          # Group subdomains in service tags together.
+          # Group external subdomains in service tags or komoju environments together.
           Datadog::Tracing::Pipeline::SpanProcessor.new do |span|
             span.service = "myshopify.com" if span.service.end_with?("myshopify.com")
             span.service = "ngrok.io" if span.service.end_with?("ngrok.io")
             span.service = "ngrok-free.app" if span.service.end_with?("ngrok-free.app")
+            span.service = "redemption" if span.service.match /.*redemption.*komoju\.com/
           end,
           # Set service tags for AWS services.
           Datadog::Tracing::Pipeline::SpanProcessor.new do |span|

--- a/lib/degica_datadog/tracing.rb
+++ b/lib/degica_datadog/tracing.rb
@@ -74,7 +74,7 @@ module DegicaDatadog
             span.service = "myshopify.com" if span.service.end_with?("myshopify.com")
             span.service = "ngrok.io" if span.service.end_with?("ngrok.io")
             span.service = "ngrok-free.app" if span.service.end_with?("ngrok-free.app")
-            span.service = "redemption" if span.service.match /.*redemption.*komoju\.com/
+            span.service = "redemption" if span.service.match(/.*redemption.*komoju\.com/)
           end,
           # Set service tags for AWS services.
           Datadog::Tracing::Pipeline::SpanProcessor.new do |span|


### PR DESCRIPTION
## Context

In order to reduce confusion and duplication in Datadog; normalize the service name in clients that may be calling redemption so that it matches the service name being reported to datadog by the redemption system.

Redemption service environments currently live in the following domains. 
* `redemption.test.komoju.com`
* `redemption.bhn-preprod.komoju.com`
* `redemption.bhn.komoju.com`
* `redemption.komoju.com`

So we are matching on those and normalizing to `redemption`.

Datadog currently has two services "redemption.komoju.com" and "redemption". According to this thread https://degica.slack.com/archives/CTG3QN2C9/p1727823169704789 the `redemption.komoju.com` service name is coming from faraday requests in HATS while `redemption` is from the redemption system itself.

This is causing confusion as it means we have two services with unclear differences between the two and data spread out across multiple services. 

![image](https://github.com/user-attachments/assets/7f97ca53-d9d3-4a17-a865-785535db0699)

![image](https://github.com/user-attachments/assets/aa0b479b-c8f1-47df-98d3-bb2b899a0bc2)

![image](https://github.com/user-attachments/assets/5895b79e-cb1e-4f80-905d-698a13af53c8)

And finally it adds an extra step in dependency graphs that do not add any useful information.

![image](https://github.com/user-attachments/assets/17b9af5e-319a-4525-96c4-492bbbc9aa4f)

It also adds some conceptual friction in that it uses specific environment domain names (e.g. redemption.komoju.com) but also has a separate environment tag `production` which is
* Redundant
* Could lead to conflict issues if we ever have a different environment metric'd such as `staging` or `bhn-preprod` (The latter of which is currently reporting under `production`).
* Would proliferate the number of "Domain name" services in DataDog.

Finally the Redemption system will be handling traffic from both Komoju internal (HATS) and Komoju external (Valve etc.) services so reducing visual clutter and streamlining will be important.

Losing historical data for `redemption.komoju.com` is not a problem.
