### PR TITLE
Updated aws_region environment variable name to DD_AWS_REGION

### DIFF
--- a/lib/degica_datadog/config.rb
+++ b/lib/degica_datadog/config.rb
@@ -73,7 +73,7 @@ module DegicaDatadog
       end
 
       def aws_region
-        @aws_region ||= ENV.fetch("DD_AWS_REGION", nil)
+        @aws_region ||= ENV.fetch("O11Y_AWS_REGION", nil)
       end
 
       def inspect

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe DegicaDatadog::Config do
         allow(ENV).to receive(:fetch).with("PLATFORM", "").and_return("")
         allow(ENV).to receive(:fetch).with("_GIT_REVISION", "unknown").and_return(version)
         allow(ENV).to receive(:fetch).with("O11Y_ENV", nil).and_return(environment)
-        allow(ENV).to receive(:fetch).with("DD_AWS_REGION", nil).and_return("ap-northeast-1")
+        allow(ENV).to receive(:fetch).with("O11Y_AWS_REGION", nil).and_return("ap-northeast-1")
       end
 
       it "sets service_name correctly" do
@@ -239,12 +239,12 @@ RSpec.describe DegicaDatadog::Config do
     end
 
     it "returns the AWS region from environment variable" do
-      allow(ENV).to receive(:fetch).with("DD_AWS_REGION", nil).and_return("ap-northeast-1")
+      allow(ENV).to receive(:fetch).with("O11Y_AWS_REGION", nil).and_return("ap-northeast-1")
       expect(described_class.aws_region).to eq("ap-northeast-1")
     end
 
-    it "returns nil when DD_AWS_REGION is not set" do
-      allow(ENV).to receive(:fetch).with("DD_AWS_REGION", nil).and_return(nil)
+    it "returns nil when O11Y_AWS_REGION is not set" do
+      allow(ENV).to receive(:fetch).with("O11Y_AWS_REGION", nil).and_return(nil)
       expect(described_class.aws_region).to be_nil
     end
   end


### PR DESCRIPTION
Continuation of [PR](https://github.com/komoju/degica_datadog/pull/43)

Renamed `AWS_REGION` to `DD_AWS_REGION` to support dynamic region configuration during CPP deployments.

The current hardcoded value (ap-northeast-1) used by the HATS application can cause issues when deploying to the DR (Singapore) region. ([REF](https://github.com/search?q=repo%3Akomoju%2Fhats%20aws_region&type=code))

I will add a new environment variable to support DD_AWS_REGION across all applications. 

This change enables region-specific deployments without impacting existing setups.