### PR TITLE
ci: migrate workflows to self-hosted runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   rspec:
-    runs-on: [self-hosted, spot]
+    runs-on: [self-hosted, on-demand]
     name: Run rspec
     permissions: write-all
     strategy:
@@ -42,7 +42,7 @@ jobs:
       if: always()
       run: rm -rf ./* ./.??* || true; ls -al
   rubocop:
-    runs-on: [self-hosted, spot]
+    runs-on: [self-hosted, on-demand]
     name: Run rubocop
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   rspec:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, spot]
     name: Run rspec
     permissions: write-all
     strategy:
@@ -38,8 +38,11 @@ jobs:
           show_missing: true
           link_missing_lines: true
 
+    - name: Clean Workspace Folder
+      if: always()
+      run: rm -rf ./* ./.??* || true; ls -al
   rubocop:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, spot]
     name: Run rubocop
 
     steps:
@@ -54,3 +57,6 @@ jobs:
 
       - name: Run RuboCop
         run: bundle exec rubocop
+      - name: Clean Workspace Folder
+        if: always()
+        run: rm -rf ./* ./.??* || true; ls -al


### PR DESCRIPTION
## Migration summary

Migrate GitHub-hosted runners to self-hosted runners as part of the GitHub org IP allowlist restriction (SEC-627, deadline May 29).

**Runner label mapping:**

| Old | New | Reason |
|-----|-----|--------|
| `ubuntu-latest` | `[self-hosted, spot]` | regular CI — xlarge spot |

**Changed workflows:**

- `.github/workflows/main.yml`
  - `rspec` → `spot`
  - `rubocop` → `spot`

If any jobs fail, please ping @harsh-gulhane

**Reference:** [GitHub IP Restriction](https://www.notion.so/GitHub-IP-Restriction-35e0fbdadd16807eb887e963924d92e0)